### PR TITLE
__overwrite fix for nested properties that aren't found in original obj

### DIFF
--- a/tunguska:gauge.js
+++ b/tunguska:gauge.js
@@ -216,6 +216,7 @@ TunguskaGauge.prototype = {
     'use strict';
     if ('undefined' === typeof copy) {
       copy = obj;
+			return obj;
     } else {
       // Handle the 3 simple types, and null or undefined
       if (null === obj || 'object' !== typeof obj) {

--- a/tunguska:gauge.js
+++ b/tunguska:gauge.js
@@ -216,7 +216,7 @@ TunguskaGauge.prototype = {
     'use strict';
     if ('undefined' === typeof copy) {
       copy = obj;
-			return obj;
+      return copy;
     } else {
       // Handle the 3 simple types, and null or undefined
       if (null === obj || 'object' !== typeof obj) {


### PR DESCRIPTION
Just raised an issue that I discovered when attempting to set a callback for the major tick legend. Because __overwrite expects something returned on a nested property, anything property not set in the original theme gets thrown out. A simple return has been added.
